### PR TITLE
Add Oxide toggle and auto-update for Rust servers

### DIFF
--- a/WindowsGSM/Functions/ServerConfig.cs
+++ b/WindowsGSM/Functions/ServerConfig.cs
@@ -37,6 +37,7 @@ namespace WindowsGSM.Functions
             public const string CPUPriority = "cpupriority";
             public const string CPUAffinity = "cpuaffinity";
             public const string AutoScroll = "autoscroll";
+            public const string Oxide = "oxide";
         }
 
         public string ServerID;
@@ -68,6 +69,7 @@ namespace WindowsGSM.Functions
         public string CPUPriority;
         public string CPUAffinity;
         public bool AutoScroll;
+        public bool Oxide;
 
         public ServerConfig(string serverid)
         {
@@ -139,6 +141,7 @@ namespace WindowsGSM.Functions
                             case SettingName.CPUPriority: CPUPriority = keyvalue[1]; break;
                             case SettingName.CPUAffinity: CPUAffinity = keyvalue[1]; break;
                             case SettingName.AutoScroll: AutoScroll = keyvalue[1] == "1"; break;
+                            case SettingName.Oxide: Oxide = keyvalue[1] == "1"; break;
                         }
                     }
                 }
@@ -176,6 +179,7 @@ namespace WindowsGSM.Functions
             CPUPriority = "2";
             CPUAffinity = string.Concat(System.Linq.Enumerable.Repeat("1", Environment.ProcessorCount));
             AutoScroll = true;
+            Oxide = false;
         }
 
         public bool CreateWindowsGSMConfig()
@@ -223,6 +227,7 @@ namespace WindowsGSM.Functions
                     textwriter.WriteLine($"{SettingName.AutoUpdateAlert}=\"1\"");
                     textwriter.WriteLine($"{SettingName.RestartCrontabAlert}=\"1\"");
                     textwriter.WriteLine($"{SettingName.CrashAlert}=\"1\"");
+                    textwriter.WriteLine($"{SettingName.Oxide}=\"0\"");
                 }
 
                 return true;

--- a/WindowsGSM/MainWindow.xaml
+++ b/WindowsGSM/MainWindow.xaml
@@ -237,6 +237,8 @@
                             <TextBox x:Name="textbox_InstallServerName" Height="23" TextWrapping="Wrap" Text="" VerticalAlignment="Top"/>
                         </DockPanel>
 
+                        <mah:ToggleSwitch x:Name="switch_InstallOxide" Margin="0,0,0,15" Header="Install OxideMod" Visibility="Collapsed"/>
+
                         <DockPanel Margin="0,0,0,15" DockPanel.Dock="Top">
                             <Button x:Name="button_InstallSetAccount" Content="Set Account" DockPanel.Dock="Left" Width="120" Margin="0,0,5,0" Click="Button_SetAccount_Click"/>
                             <Button x:Name="button_Install" Content="Install" VerticalAlignment="Top" Click="Button_Install_Click"/>
@@ -755,6 +757,9 @@
 
                         <Label Content="Auto Update" HorizontalAlignment="Left" Margin="338,127,0,0" VerticalAlignment="Top"/>
                         <mah:ToggleSwitch x:Name="switch_autoupdate" Margin="422,125,0,0" VerticalAlignment="Top" HorizontalAlignment="Left" Toggled="Button_AutoUpdate_Click" Width="44" Height="30"/>
+
+                        <Label x:Name="label_oxide" Content="Oxide" HorizontalAlignment="Left" Margin="475,127,0,0" VerticalAlignment="Top" Visibility="Collapsed"/>
+                        <mah:ToggleSwitch x:Name="switch_oxide" Margin="545,125,0,0" VerticalAlignment="Top" HorizontalAlignment="Left" Toggled="Button_Oxide_Click" Width="44" Height="30" Visibility="Collapsed"/>
 
                         <Label Content="Update on Start" HorizontalAlignment="Left" Margin="159,99,0,0" VerticalAlignment="Top"/>
                         <mah:ToggleSwitch x:Name="switch_updateonstart" Margin="258,97,0,0" VerticalAlignment="Top" HorizontalAlignment="Left" Toggled="Button_UpdateOnStart_Click" Width="44" Height="30"/>


### PR DESCRIPTION
## Summary
- add `oxide` server configuration option
- allow installing Oxide mod through new toggle during install and in server controls
- update Oxide when Rust servers auto-update or are manually updated

## Testing
- `dotnet build WindowsGSM.sln` *(fails: The reference assemblies for .NETFramework,Version=v4.7.2 were not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9bf294f08321bf732f5338f66c24