### PR TITLE
Upgrade Newtonsoft.Json to 13.0.2 and clean references

### DIFF
--- a/WindowsGSM-Plugin-Development/WindowsGSM-Plugin-Development.csproj
+++ b/WindowsGSM-Plugin-Development/WindowsGSM-Plugin-Development.csproj
@@ -36,8 +36,8 @@
     <NoWarn>1998</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/WindowsGSM-Plugin-Development/packages.config
+++ b/WindowsGSM-Plugin-Development/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net472" />
 </packages>

--- a/WindowsGSM/App.config
+++ b/WindowsGSM/App.config
@@ -13,7 +13,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/WindowsGSM/Properties/Resources.Designer.cs
+++ b/WindowsGSM/Properties/Resources.Designer.cs
@@ -73,16 +73,6 @@ namespace WindowsGSM.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Byte[].
         /// </summary>
-        internal static byte[] Newtonsoft_Json {
-            get {
-                object obj = ResourceManager.GetObject("Newtonsoft_Json", resourceCulture);
-                return ((byte[])(obj));
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized resource of type System.Byte[].
-        /// </summary>
         internal static byte[] roslyn {
             get {
                 object obj = ResourceManager.GetObject("roslyn", resourceCulture);

--- a/WindowsGSM/Properties/Resources.resx
+++ b/WindowsGSM/Properties/Resources.resx
@@ -121,9 +121,6 @@
   <data name="MahApps_Metro" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\..\packages\MahApps.Metro.2.1.1\lib\net47\MahApps.Metro.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="Newtonsoft_Json" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\..\packages\newtonsoft.json.12.0.3\lib\net45\newtonsoft.json.dll;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
   <data name="roslyn" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\roslyn.zip;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>

--- a/WindowsGSM/WindowsGSM.csproj
+++ b/WindowsGSM/WindowsGSM.csproj
@@ -808,11 +808,6 @@
     <Resource Include="Images\HMenu\ViewPlugins.ico" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll">
-      <Link>ReferencesEx\Newtonsoft.Json.dll</Link>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll">
       <Link>ReferencesEx\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</Link>
     </EmbeddedResource>


### PR DESCRIPTION
## Summary
- align plugin dev packages with main project by updating Newtonsoft.Json to 13.0.2
- update App.config bindingRedirect to 13.0.0.0
- remove embedded Newtonsoft.Json resources and rely on NuGet package

## Testing
- `mono /usr/local/bin/nuget.exe restore WindowsGSM.sln`
- `xbuild WindowsGSM.sln /t:Build /p:Configuration=Release` *(fails: DiscordBot/Commands.cs(107,66): error CS1525: Unexpected symbol `in`)*

------
https://chatgpt.com/codex/tasks/task_e_68adc003b7b08321aafafe63312d8825