### PR TITLE
refactor: restore packages ignore and use SharpZipLib package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ WindowsGSM/obj/
 WindowsGSM-Plugin-Development/bin/
 WindowsGSM-Plugin-Development/obj/
 WindowsGSM.sln.DotSettings.user
-packages/SharpZipLib.*/
+packages/
 

--- a/WindowsGSM/WindowsGSM.csproj
+++ b/WindowsGSM/WindowsGSM.csproj
@@ -130,10 +130,6 @@
       <HintPath>..\packages\Discord.Net.WebSocket.2.2.0\lib\net461\Discord.Net.WebSocket.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=1.4.2.0, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpZipLib.1.4.2\lib\netstandard2.0\ICSharpCode.SharpZipLib.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="LiveCharts, Version=0.9.7.0, Culture=neutral, PublicKeyToken=0bc1f845d1ebb8df, processorArchitecture=MSIL">
       <HintPath>..\packages\LiveCharts.0.9.7\lib\net45\LiveCharts.dll</HintPath>
       <Private>False</Private>
@@ -809,6 +805,9 @@
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Images\Plugins\User.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets" Condition="Exists('..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" />

--- a/WindowsGSM/packages.config
+++ b/WindowsGSM/packages.config
@@ -20,7 +20,6 @@
   <package id="NCrontab.Signed" version="3.3.2" targetFramework="net472" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net472" />
-  <package id="SharpZipLib" version="1.4.2" targetFramework="net472" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Collections" version="4.3.0" targetFramework="net472" />


### PR DESCRIPTION
## Summary
- ignore entire `packages/` directory again
- reference SharpZipLib 1.4.2 via PackageReference and drop dll hint
- remove SharpZipLib entry from `packages.config`

## Testing
- `mono nuget.exe restore WindowsGSM.sln`

------
https://chatgpt.com/codex/tasks/task_e_68add2a08f308321a84f8469f639ffd1